### PR TITLE
Fix: Ensuring use of JavaScripts actual min/max numbers

### DIFF
--- a/ombb.js
+++ b/ombb.js
@@ -49,8 +49,8 @@ function CalcOmbb(convexHull)
     }
     
     // compute extreme points
-    var minPt = new Vector(Number.MAX_VALUE, Number.MAX_VALUE);
-    var maxPt = new Vector(Number.MIN_VALUE, Number.MIN_VALUE);
+    var minPt = new Vector(Number.POSITIVE_INFINITY, Number.POSITIVE_INFINITY);
+    var maxPt = new Vector(Number.NEGATIVE_INFINITY, Number.NEGATIVE_INFINITY);
     var leftIdx, rightIdx, topIdx, bottomIdx;
    
     for (var i=0; i<convexHull.length; i++)


### PR DESCRIPTION
This helps to ensure initial extreme points are being properly taken into account. JavaScript's actual min/max numbers (for comparison) are `Number.POSITIVE_INFINITY` and `Number.NEGATIVE_INFINITY`. 

Turns out that `Number.MIN_VALUE` is actually positive, since it is just the [smallest _positive_ number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/MIN_VALUE) that a floating point can represent, which I also didn't realize until now. So, this would sometimes crash because one of the indexes (e.g. `leftIdx`) would be undefined when accessing `edgeDirs`, so  `Math.acos(leftDir.dot(edgeDirs[leftIdx]))` would fail.